### PR TITLE
change entry type from string to DeviceEntryType

### DIFF
--- a/custom_components/greenely/sensor.py
+++ b/custom_components/greenely/sensor.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo, DeviceEntryType
 from homeassistant.helpers.entity import Entity
 
 from . import GreenelyData
@@ -156,7 +156,7 @@ class GreenelyDailyUsageSensor(Entity):
             name="Greenely",
             identifiers={(DOMAIN, self._facility_id)},
             manufacturer="Greenely",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
         )
 
     @property
@@ -253,7 +253,7 @@ class GreenelyHourlyUsageSensor(Entity):
             name="Greenely",
             identifiers={(DOMAIN, self._facility_id)},
             manufacturer="Greenely",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
         )
 
     @property
@@ -355,7 +355,7 @@ class GreenelyPricesSensor(Entity):
             name="Greenely",
             identifiers={(DOMAIN, self._facility_id)},
             manufacturer="Greenely",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
         )
 
     def update(self):
@@ -506,7 +506,7 @@ class GreenelyDailyProducedElecticitySensor(Entity):
             name="Greenely",
             identifiers={(DOMAIN, self._facility_id)},
             manufacturer="Greenely",
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
         )
 
     def update(self):


### PR DESCRIPTION
This pull request includes several changes to the `custom_components/greenely/sensor.py` file to standardize the use of `DeviceEntryType.SERVICE` for device entry types. The most important changes include importing `DeviceEntryType` and updating the `entry_type` attribute in multiple instances of the `device_info` method.

Standardization of `DeviceEntryType`:

* [`custom_components/greenely/sensor.py`](diffhunk://#diff-e36fb74c5247ee16cffc9dafa2a690d625787aee7587789874b04155c97687acL7-R7): Imported `DeviceEntryType` from `homeassistant.helpers.device_registry`.
* [`custom_components/greenely/sensor.py`](diffhunk://#diff-e36fb74c5247ee16cffc9dafa2a690d625787aee7587789874b04155c97687acL159-R159): Updated the `entry_type` attribute to use `DeviceEntryType.SERVICE` in the `device_info` method. [[1]](diffhunk://#diff-e36fb74c5247ee16cffc9dafa2a690d625787aee7587789874b04155c97687acL159-R159) [[2]](diffhunk://#diff-e36fb74c5247ee16cffc9dafa2a690d625787aee7587789874b04155c97687acL256-R256) [[3]](diffhunk://#diff-e36fb74c5247ee16cffc9dafa2a690d625787aee7587789874b04155c97687acL358-R358) [[4]](diffhunk://#diff-e36fb74c5247ee16cffc9dafa2a690d625787aee7587789874b04155c97687acL509-R509)